### PR TITLE
GitHub Action for MHC Prod-Mulitdeployment

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -16,19 +16,19 @@ on:
     inputs:
       environment:
         description: |
-          The GitHub deployment environment.
+          The GitHub deployment environment
         required: true
         default: 'development'
         type: choice
         options:
-          - development
           - staging
-          - production
+          - production-us
+          - production-uk
   workflow_call:
     inputs:
       environment:
         description: |
-          The GitHub deployment environment.
+          The GitHub deployment environment
         required: false
         type: string
         default: development


### PR DESCRIPTION
# GitHub Action for MHC Prod-Mulitdeployment

## :recycle: Current situation & Problem
Currently, we only use one prod-deployment, but MHC will need two of them.


## :gear: Release Notes
This is a minor PR to have two prod-deployments instead of one.


## :books: Documentation
Not needed


## :white_check_mark: Testing
Not needed


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
