### PR TITLE
Fix static URLs to parse Questionnaires

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -108,4 +108,8 @@ service cloud.firestore {
         || (isClinicianForThisPatient() && isClinicianWritableCollectionName());
     }
   }
+  match /feedback/{id} {
+    allow read: if false;
+    allow write: if isAuthenticated();
+  }
 }

--- a/functions/src/services/database/collections.ts
+++ b/functions/src/services/database/collections.ts
@@ -98,4 +98,12 @@ export class CollectionsService {
       .collection('scores')
       .withConverter(new DatabaseConverter(scoreConverter))
   }
+
+  userHealthObservations(userId: string, collectionName: string) {
+    return this.firestore
+      .collection('users')
+      .doc(userId)
+      .collection(collectionName)
+      .withConverter(new DatabaseConverter(fhirObservationConverter.value))
+  }
 }

--- a/functions/src/services/questionnaireResponse/dietScoringService.ts
+++ b/functions/src/services/questionnaireResponse/dietScoringService.ts
@@ -167,8 +167,9 @@ export class DietScoringQuestionnaireResponseService extends QuestionnaireRespon
   ): Promise<boolean> {
     // Check if this service handles this questionnaire type
     const targetQuestionnaireUrls = [
-      '58C1E077-5BAF-491D-BEAC-48AA8B5D68D2', // Diet questionnaire UUID
+      'https://myheartcounts.stanford.edu/fhir/survey/dietScore',
     ]
+
     if (!targetQuestionnaireUrls.includes(response.content.questionnaire)) {
       return false
     }

--- a/functions/src/services/questionnaireResponse/fhirObservationConverter.ts
+++ b/functions/src/services/questionnaireResponse/fhirObservationConverter.ts
@@ -1,0 +1,118 @@
+//
+// This source file is part of the MyHeartCounts-Firebase project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import {
+  FHIRObservation,
+  FHIRObservationStatus,
+  type Score,
+  type FHIRCodeableConcept,
+} from '@stanfordbdhg/myheartcounts-models'
+
+export interface QuestionnaireObservationConfig {
+  loincCode: string
+  customCode: string
+  display: string
+  unit: string
+  unitSystem: string
+}
+
+export function scoreToObservation(
+  score: Score,
+  config: QuestionnaireObservationConfig,
+  questionnaireResponseId: string,
+  observationId: string,
+): FHIRObservation {
+  const codeableConcept: FHIRCodeableConcept = {
+    coding: [
+      {
+        code: config.loincCode,
+        system: 'http://loinc.org',
+      },
+      {
+        code: config.customCode,
+        display: config.display,
+        system: 'https://spezi.stanford.edu',
+      },
+    ],
+  }
+
+  return new FHIRObservation({
+    id: observationId,
+    status: FHIRObservationStatus.final,
+    code: codeableConcept,
+    valueQuantity: {
+      value: score.overallScore,
+      unit: config.unit,
+      system: config.unitSystem,
+      code: config.loincCode,
+    },
+    effectiveDateTime: score.date,
+    extension: [
+      {
+        url: 'https://bdh.stanford.edu/fhir/defs/sampleUploadTimeZone',
+        valueString: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      },
+      {
+        url: 'https://bdh.stanford.edu/fhir/defs/sourceRevision/source/name',
+        valueString: 'My Heart Counts',
+      },
+      {
+        url: 'https://bdh.stanford.edu/fhir/defs/sourceRevision/source/bundleIdentifier',
+        valueString: 'edu.stanford.MyHeartCounts',
+      },
+      {
+        url: 'https://bdh.stanford.edu/fhir/defs/sourceRevision/version',
+        valueString: '3.0.0 (955)',
+      },
+      {
+        url: 'https://bdh.stanford.edu/fhir/defs/sourceRevision/OSVersion',
+        valueString: '18.5.0',
+      },
+      {
+        url: 'http://hl7.org/fhir/StructureDefinition/derivedFrom',
+        valueString: `QuestionnaireResponse/${questionnaireResponseId}`,
+      },
+      {
+        url: 'http://hl7.org/fhir/StructureDefinition/issued',
+        valueString: new Date().toISOString(),
+      },
+      {
+        url: 'http://hl7.org/fhir/StructureDefinition/identifier',
+        valueString: observationId,
+      },
+    ],
+  })
+}
+
+export function getDietObservationConfig(): QuestionnaireObservationConfig {
+  return {
+    loincCode: '67504-6', // Nutrition assessment LOINC code
+    customCode: 'MHCCustomSampleTypeDietMEPAScore',
+    display: 'Diet MEPA Score',
+    unit: 'score',
+    unitSystem: 'http://loinc.org',
+  }
+}
+
+export function getNicotineObservationConfig(): QuestionnaireObservationConfig {
+  return {
+    loincCode: '72166-2', // Tobacco use status LOINC code
+    customCode: 'MHCCustomSampleTypeNicotineExposure',
+    display: 'Nicotine Exposure Score',
+    unit: 'score',
+    unitSystem: 'http://loinc.org',
+  }
+}
+
+export function generateUUID(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0
+    const v = c === 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16).toUpperCase()
+  })
+}

--- a/functions/src/services/questionnaireResponse/nicotineScoringService.ts
+++ b/functions/src/services/questionnaireResponse/nicotineScoringService.ts
@@ -11,6 +11,12 @@ import {
   type FHIRQuestionnaireResponse,
 } from '@stanfordbdhg/myheartcounts-models'
 import { logger } from 'firebase-functions'
+import {
+  scoreToObservation,
+  getNicotineObservationConfig,
+  generateUUID,
+  type QuestionnaireObservationConfig,
+} from './fhirObservationConverter.js'
 import { QuestionnaireResponseService } from './questionnaireResponseService.js'
 import {
   type Document,
@@ -95,6 +101,9 @@ export class NicotineScoringQuestionnaireResponseService extends QuestionnaireRe
 
       // Store new score
       await this.updateScore(userId, response.id, score)
+
+      // Store FHIR observation
+      await this.storeFHIRObservation(userId, response.id, score)
 
       // Implement business logic (e.g., decline detection)
       if (previousScore && this.isSignificantDecline(previousScore, score)) {
@@ -202,5 +211,30 @@ export class NicotineScoringQuestionnaireResponseService extends QuestionnaireRe
 
     // Could send a message to the user or healthcare provider about smoking status changes
     // await this.messageService.addMessage(userId, AlertMessage.createNicotineScoreDecline(...))
+  }
+
+  private async storeFHIRObservation(
+    userId: string,
+    questionnaireResponseId: string,
+    score: Score,
+  ): Promise<void> {
+    const config = getNicotineObservationConfig()
+    const observationId = generateUUID()
+    const observation = scoreToObservation(
+      score,
+      config,
+      questionnaireResponseId,
+      observationId,
+    )
+
+    const collectionName =
+      'HealthObservations_MHCCustomSampleTypeNicotineExposure'
+
+    return this.databaseService.runTransaction((collections, transaction) => {
+      const ref = collections
+        .userHealthObservations(userId, collectionName)
+        .doc(observationId)
+      transaction.set(ref, observation)
+    })
   }
 }

--- a/functions/src/services/questionnaireResponse/nicotineScoringService.ts
+++ b/functions/src/services/questionnaireResponse/nicotineScoringService.ts
@@ -78,8 +78,9 @@ export class NicotineScoringQuestionnaireResponseService extends QuestionnaireRe
   ): Promise<boolean> {
     // Check if this service handles this questionnaire type
     const targetQuestionnaireUrls = [
-      '91EB378F-B851-46AC-865A-E0013CA95886', // Nicotine questionnaire UUID
+      'https://myheartcounts.stanford.edu/fhir/survey/nicotineExposure',
     ]
+
     if (!targetQuestionnaireUrls.includes(response.content.questionnaire)) {
       return false
     }

--- a/functions/src/tests/services/questionnaireResponse/dietScoringService.test.ts
+++ b/functions/src/tests/services/questionnaireResponse/dietScoringService.test.ts
@@ -195,7 +195,8 @@ describe('DietScoringQuestionnaireResponseService', () => {
         content: new FHIRQuestionnaireResponse({
           id: 'test-response',
           authored: new Date(),
-          questionnaire: '58C1E077-5BAF-491D-BEAC-48AA8B5D68D2',
+          questionnaire:
+            'https://myheartcounts.stanford.edu/fhir/survey/dietScore',
           item: [],
         }),
       }

--- a/functions/src/tests/services/questionnaireResponse/nicotineScoringService.test.ts
+++ b/functions/src/tests/services/questionnaireResponse/nicotineScoringService.test.ts
@@ -127,7 +127,8 @@ describe('NicotineScoringQuestionnaireResponseService', () => {
         content: new FHIRQuestionnaireResponse({
           id: 'test-response',
           authored: new Date(),
-          questionnaire: '91EB378F-B851-46AC-865A-E0013CA95886',
+          questionnaire:
+            'https://myheartcounts.stanford.edu/fhir/survey/nicotineExposure',
           item: [
             {
               linkId: 'a77ec6ab-8f37-4db4-8c5b-19a0d10964b9',
@@ -173,8 +174,14 @@ describe('NicotineScoringQuestionnaireResponseService', () => {
         content: new FHIRQuestionnaireResponse({
           id: 'test-response',
           authored: new Date(),
-          questionnaire: '91EB378F-B851-46AC-865A-E0013CA95886',
-          item: [], // No items - should return false
+          questionnaire:
+            'https://myheartcounts.stanford.edu/fhir/survey/nicotineExposure',
+          item: [
+            {
+              linkId: 'a77ec6ab-8f37-4db4-8c5b-19a0d10964b9',
+              answer: [], // No answer - should return false
+            },
+          ],
         }),
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "myheartcounts-firebase",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "myheartcounts-firebase",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
# Fix static URLs to parse Questionnaires

## :recycle: Current situation & Problem
It was initally thought about detecting the questionnaire type by ID, but that changed to URL. This PR fixes this assumption and implements URLs as the detection method to find out the questionnaire type.


## :gear: Release Notes
N/A


## :books: Documentation
N/A

## :white_check_mark: Testing
test was editied to reflect this fix.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
