### PR TITLE
Use separate project IDs in prod Deployment

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -73,9 +73,14 @@ jobs:
     environment: ${{ needs.determineenvironment.outputs.environment }}
     outputs:
       FIREBASE_PROJECT_ID: ${{ vars.FIREBASE_PROJECT_ID }}
+      FIREBASE_PROJECT_ID_PRODUCTION_US: ${{ vars.FIREBASE_PROJECT_ID_PRODUCTION_US }}
+      FIREBASE_PROJECT_ID_PRODUCTION_UK: ${{ vars.FIREBASE_PROJECT_ID_PRODUCTION_UK }}
     steps:
       - run: |
-          echo "Injecting Environment Variables In Deployment Workflow: ${{ vars.FIREBASE_PROJECT_ID }}"
+          echo "Injecting Environment Variables In Deployment Workflow"
+          echo "FIREBASE_PROJECT_ID: ${{ vars.FIREBASE_PROJECT_ID }}"
+          echo "FIREBASE_PROJECT_ID_PRODUCTION_US: ${{ vars.FIREBASE_PROJECT_ID_PRODUCTION_US }}"
+          echo "FIREBASE_PROJECT_ID_PRODUCTION_UK: ${{ vars.FIREBASE_PROJECT_ID_PRODUCTION_UK }}"
 
   buildandtest:
     name: Build and Test
@@ -112,7 +117,7 @@ jobs:
     with:
       customcommand: "npm run prepare"
       environment: production
-      arguments: '--project ${{ needs.vars.outputs.FIREBASE_PROJECT_ID }}'
+      arguments: '--project ${{ needs.vars.outputs.FIREBASE_PROJECT_ID_PRODUCTION_US }}'
     secrets:
       GOOGLE_APPLICATION_CREDENTIALS_BASE64: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64_PRODUCTION_US }}
 
@@ -127,6 +132,6 @@ jobs:
     with:
       customcommand: "npm run prepare"
       environment: production
-      arguments: '--project ${{ needs.vars.outputs.FIREBASE_PROJECT_ID }}'
+      arguments: '--project ${{ needs.vars.outputs.FIREBASE_PROJECT_ID_PRODUCTION_UK }}'
     secrets:
       GOOGLE_APPLICATION_CREDENTIALS_BASE64: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64_PRODUCTION_UK }}


### PR DESCRIPTION
# Use separate project IDs in prod Deployment

## :recycle: Current situation & Problem
See Diff, should fix prod release

## :gear: Release Notes
N/A


## :books: Documentation
N/A

## :white_check_mark: Testing
N/A


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
