### PR TITLE
Remove pending 'to be deleted' HK Samples

### DIFF
--- a/functions/src/functions/processPendingHealthSampleDeletions.ts
+++ b/functions/src/functions/processPendingHealthSampleDeletions.ts
@@ -3,7 +3,6 @@
 // SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
 // SPDX-License-Identifier: MIT
 
-import { logger } from "firebase-functions/v2";
 import { onSchedule } from "firebase-functions/v2/scheduler";
 import { privilegedServiceAccount } from "./helpers.js";
 import { HealthSampleDeletionQueueService } from "../services/healthSamples/healthSampleDeletionQueueService.js";
@@ -16,12 +15,7 @@ export const processPendingHealthSampleDeletions = onSchedule(
     serviceAccount: privilegedServiceAccount,
   },
   async (_event) => {
-    logger.info("Starting scheduled pending health sample deletion processing");
     const queueService = new HealthSampleDeletionQueueService();
-    const result = await queueService.processQueue();
-    logger.info(
-      "Completed scheduled pending health sample deletion processing",
-      result,
-    );
+    await queueService.processQueue();
   },
 );

--- a/functions/src/services/healthSamples/healthSampleDeletionQueueService.test.ts
+++ b/functions/src/services/healthSamples/healthSampleDeletionQueueService.test.ts
@@ -416,18 +416,13 @@ describeWithEmulators("service: HealthSampleDeletionQueueService", (env) => {
         .get();
       expect(pendingSnapshot.size).to.equal(0);
 
+      // Final-attempt failures are dropped, not persisted indefinitely.
       const failedSnapshot = await env.firestore
         .collection("users")
         .doc(userId)
         .collection("failedHealthSampleDeletions")
         .get();
-      expect(failedSnapshot.size).to.equal(1);
-
-      const failedData = failedSnapshot.docs[0].data();
-      expect(failedData.documentId).to.equal("doc1");
-      expect(failedData.retryCount).to.equal(10);
-      expect(failedData.lastError).to.equal("DEADLINE_EXCEEDED");
-      expect(failedData.failedAt).to.be.an.instanceOf(Timestamp);
+      expect(failedSnapshot.size).to.equal(0);
     });
 
     it("should skip items where payload userId does not match path owner", async () => {

--- a/functions/src/services/healthSamples/healthSampleDeletionQueueService.test.ts
+++ b/functions/src/services/healthSamples/healthSampleDeletionQueueService.test.ts
@@ -112,8 +112,9 @@ describeWithEmulators("service: HealthSampleDeletionQueueService", (env) => {
       );
     });
 
-    it("should set nextRetryAt 30s in the future for NOT_FOUND", async () => {
+    it("should set nextRetryAt 8h in the future for NOT_FOUND", async () => {
       const before = Timestamp.now().toMillis();
+      const eightHoursMs = 8 * 60 * 60 * 1000;
 
       await queueService.enqueue({
         userId: "user1",
@@ -132,8 +133,8 @@ describeWithEmulators("service: HealthSampleDeletionQueueService", (env) => {
         .get();
       const data = snapshot.docs[0].data();
       const nextRetryMs = (data.nextRetryAt as Timestamp).toMillis();
-      expect(nextRetryMs).to.be.greaterThanOrEqual(before + 30_000);
-      expect(nextRetryMs).to.be.lessThanOrEqual(before + 32_000);
+      expect(nextRetryMs).to.be.greaterThanOrEqual(before + eightHoursMs);
+      expect(nextRetryMs).to.be.lessThanOrEqual(before + eightHoursMs + 2_000);
     });
 
     it("should set nextRetryAt 8h in the future for TRANSIENT_ERROR", async () => {
@@ -244,10 +245,9 @@ describeWithEmulators("service: HealthSampleDeletionQueueService", (env) => {
       expect(queueSnapshot.size).to.equal(0);
     });
 
-    it("should mark NOT_FOUND target as succeeded and clear the pending entry", async () => {
-      // Seed a pending doc whose target sample does not exist. NOT_FOUND IS
-      // the desired end state of a deletion, so the worker should clear the
-      // entry rather than retry or dead-letter.
+    it("should requeue a NOT_FOUND target so a late-arriving sample can be retried", async () => {
+      // The target sample doesn't exist yet — could be a deletion request that
+      // raced ahead of the upload. The worker should retry, not short-circuit.
       await env.firestore
         .collection("users")
         .doc("nonexistent-user")
@@ -266,8 +266,8 @@ describeWithEmulators("service: HealthSampleDeletionQueueService", (env) => {
         });
 
       const result = await queueService.processQueue();
-      expect(result.succeeded).to.equal(1);
-      expect(result.requeued).to.equal(0);
+      expect(result.requeued).to.equal(1);
+      expect(result.succeeded).to.equal(0);
       expect(result.deadLettered).to.equal(0);
 
       const queueSnapshot = await env.firestore
@@ -275,46 +275,10 @@ describeWithEmulators("service: HealthSampleDeletionQueueService", (env) => {
         .doc("nonexistent-user")
         .collection("pendingHealthSampleDeletions")
         .get();
-      expect(queueSnapshot.size).to.equal(0);
-
-      const failedSnapshot = await env.firestore
-        .collection("users")
-        .doc("nonexistent-user")
-        .collection("failedHealthSampleDeletions")
-        .get();
-      expect(failedSnapshot.size).to.equal(0);
-    });
-
-    it("should clear the pending entry on NOT_FOUND even at high retryCount", async () => {
-      // Even with retryCount near the dead-letter threshold, NOT_FOUND should
-      // never dead-letter — it is the deletion's desired end state.
-      await env.firestore
-        .collection("users")
-        .doc("nonexistent-user")
-        .collection("pendingHealthSampleDeletions")
-        .add({
-          userId: "nonexistent-user",
-          collection: "HealthObservations_HKQuantityTypeIdentifierHeartRate",
-          documentId: "nonexistent-doc",
-          jobId: "job1",
-          requestingUserId: "user1",
-          reason: "TRANSIENT_ERROR",
-          lastError: "Error: 5 NOT_FOUND",
-          retryCount: 2,
-          createdAt: Timestamp.now(),
-          nextRetryAt: Timestamp.fromMillis(0),
-        });
-
-      const result = await queueService.processQueue();
-      expect(result.succeeded).to.equal(1);
-      expect(result.deadLettered).to.equal(0);
-
-      const failedSnapshot = await env.firestore
-        .collection("users")
-        .doc("nonexistent-user")
-        .collection("failedHealthSampleDeletions")
-        .get();
-      expect(failedSnapshot.size).to.equal(0);
+      expect(queueSnapshot.size).to.equal(1);
+      const data = queueSnapshot.docs[0].data();
+      expect(data.retryCount).to.equal(1);
+      expect(data.lastError).to.equal("NOT_FOUND");
     });
 
     it("should requeue with incremented retryCount on transient error", async () => {

--- a/functions/src/services/healthSamples/healthSampleDeletionQueueService.test.ts
+++ b/functions/src/services/healthSamples/healthSampleDeletionQueueService.test.ts
@@ -4,7 +4,8 @@
 // SPDX-License-Identifier: MIT
 
 import { expect } from "chai";
-import { Timestamp } from "firebase-admin/firestore";
+import { DocumentReference, Timestamp } from "firebase-admin/firestore";
+import { restore, stub } from "sinon";
 import { HealthSampleDeletionQueueService } from "./healthSampleDeletionQueueService.js";
 import { FHIRObservationStatus } from "../../models/index.js";
 import { describeWithEmulators } from "../../tests/functions/testEnvironment.js";
@@ -16,8 +17,12 @@ describeWithEmulators("service: HealthSampleDeletionQueueService", (env) => {
     queueService = new HealthSampleDeletionQueueService(env.firestore);
   });
 
+  afterEach(() => {
+    restore();
+  });
+
   describe("enqueue", () => {
-    it("should add an item to the pending deletions collection", async () => {
+    it("should add an item to the pending deletions collection at a deterministic doc id", async () => {
       await queueService.enqueue({
         userId: "user1",
         collection: "HealthObservations_HKQuantityTypeIdentifierHeartRate",
@@ -34,6 +39,9 @@ describeWithEmulators("service: HealthSampleDeletionQueueService", (env) => {
         .collection("pendingHealthSampleDeletions")
         .get();
       expect(snapshot.size).to.equal(1);
+      expect(snapshot.docs[0].id).to.equal(
+        "HealthObservations_HKQuantityTypeIdentifierHeartRate__doc1",
+      );
 
       const data = snapshot.docs[0].data();
       expect(data.userId).to.equal("user1");
@@ -45,6 +53,63 @@ describeWithEmulators("service: HealthSampleDeletionQueueService", (env) => {
       expect(data.reason).to.equal("NOT_FOUND");
       expect(data.retryCount).to.equal(0);
       expect(data.lastError).to.equal("UNKNOWN_ERROR");
+    });
+
+    it("should be idempotent on re-enqueue and preserve worker-managed retry state", async () => {
+      // Pre-seed a pending doc with worker-advanced retry state, mimicking
+      // what processQueueItem would write after several failed attempts.
+      const pendingId =
+        "HealthObservations_HKQuantityTypeIdentifierHeartRate__doc1";
+      const advancedNextRetry = Timestamp.fromMillis(
+        Date.now() + 5 * 60 * 1000,
+      );
+      await env.firestore
+        .collection("users")
+        .doc("user1")
+        .collection("pendingHealthSampleDeletions")
+        .doc(pendingId)
+        .set({
+          userId: "user1",
+          collection: "HealthObservations_HKQuantityTypeIdentifierHeartRate",
+          documentId: "doc1",
+          jobId: "originalJob",
+          requestingUserId: "user1",
+          reason: "TRANSIENT_ERROR",
+          lastError: "DEADLINE_EXCEEDED",
+          retryCount: 3,
+          createdAt: Timestamp.now(),
+          nextRetryAt: advancedNextRetry,
+        });
+
+      // Re-enqueue the same target sample from a different job — this is the
+      // duplicate path that previously created a new random-id doc on every call.
+      await queueService.enqueue({
+        userId: "user1",
+        collection: "HealthObservations_HKQuantityTypeIdentifierHeartRate",
+        documentId: "doc1",
+        jobId: "secondJob",
+        requestingUserId: "user1",
+        reason: "NOT_FOUND",
+        lastError: "Error: 5 NOT_FOUND",
+      });
+
+      const snapshot = await env.firestore
+        .collection("users")
+        .doc("user1")
+        .collection("pendingHealthSampleDeletions")
+        .get();
+      expect(snapshot.size).to.equal(1);
+      expect(snapshot.docs[0].id).to.equal(pendingId);
+
+      const data = snapshot.docs[0].data();
+      // Worker-managed fields must NOT be reset by the re-enqueue.
+      expect(data.retryCount).to.equal(3);
+      expect(data.lastError).to.equal("DEADLINE_EXCEEDED");
+      expect(data.reason).to.equal("TRANSIENT_ERROR");
+      expect(data.jobId).to.equal("originalJob");
+      expect((data.nextRetryAt as Timestamp).toMillis()).to.equal(
+        advancedNextRetry.toMillis(),
+      );
     });
 
     it("should set nextRetryAt 30s in the future for NOT_FOUND", async () => {
@@ -158,8 +223,10 @@ describeWithEmulators("service: HealthSampleDeletionQueueService", (env) => {
       expect(queueSnapshot.size).to.equal(0);
     });
 
-    it("should requeue a failed item with incremented retryCount", async () => {
-      // Enqueue with a non-existent document (will fail on update)
+    it("should mark NOT_FOUND target as succeeded and clear the pending entry", async () => {
+      // Seed a pending doc whose target sample does not exist. NOT_FOUND IS
+      // the desired end state of a deletion, so the worker should clear the
+      // entry rather than retry or dead-letter.
       await env.firestore
         .collection("users")
         .doc("nonexistent-user")
@@ -178,19 +245,28 @@ describeWithEmulators("service: HealthSampleDeletionQueueService", (env) => {
         });
 
       const result = await queueService.processQueue();
-      expect(result.requeued).to.equal(1);
+      expect(result.succeeded).to.equal(1);
+      expect(result.requeued).to.equal(0);
+      expect(result.deadLettered).to.equal(0);
 
-      // Verify retryCount was incremented
       const queueSnapshot = await env.firestore
         .collection("users")
         .doc("nonexistent-user")
         .collection("pendingHealthSampleDeletions")
         .get();
-      expect(queueSnapshot.size).to.equal(1);
-      expect(queueSnapshot.docs[0].data().retryCount).to.equal(1);
+      expect(queueSnapshot.size).to.equal(0);
+
+      const failedSnapshot = await env.firestore
+        .collection("users")
+        .doc("nonexistent-user")
+        .collection("failedHealthSampleDeletions")
+        .get();
+      expect(failedSnapshot.size).to.equal(0);
     });
 
-    it("should move item to dead-letter after max retries", async () => {
+    it("should clear the pending entry on NOT_FOUND even at high retryCount", async () => {
+      // Even with retryCount near the dead-letter threshold, NOT_FOUND should
+      // never dead-letter — it is the deletion's desired end state.
       await env.firestore
         .collection("users")
         .doc("nonexistent-user")
@@ -202,34 +278,155 @@ describeWithEmulators("service: HealthSampleDeletionQueueService", (env) => {
           jobId: "job1",
           requestingUserId: "user1",
           reason: "TRANSIENT_ERROR",
-          lastError: "Error: 4 DEADLINE_EXCEEDED",
+          lastError: "Error: 5 NOT_FOUND",
           retryCount: 9,
           createdAt: Timestamp.now(),
           nextRetryAt: Timestamp.fromMillis(0),
         });
 
       const result = await queueService.processQueue();
-      expect(result.deadLettered).to.equal(1);
+      expect(result.succeeded).to.equal(1);
+      expect(result.deadLettered).to.equal(0);
 
-      // Verify item was removed from pending
-      const pendingSnapshot = await env.firestore
-        .collection("users")
-        .doc("nonexistent-user")
-        .collection("pendingHealthSampleDeletions")
-        .get();
-      expect(pendingSnapshot.size).to.equal(0);
-
-      // Verify item was added to dead-letter
       const failedSnapshot = await env.firestore
         .collection("users")
         .doc("nonexistent-user")
         .collection("failedHealthSampleDeletions")
         .get();
+      expect(failedSnapshot.size).to.equal(0);
+    });
+
+    it("should requeue with incremented retryCount on transient error", async () => {
+      const userId = await env.createUser({});
+
+      // Create the target sample so the only failure path is the stubbed one.
+      await env.firestore
+        .collection("users")
+        .doc(userId)
+        .collection("HealthObservations_HKQuantityTypeIdentifierHeartRate")
+        .doc("doc1")
+        .set({ status: "final", value: 72 });
+
+      await env.firestore
+        .collection("users")
+        .doc(userId)
+        .collection("pendingHealthSampleDeletions")
+        .add({
+          userId,
+          collection: "HealthObservations_HKQuantityTypeIdentifierHeartRate",
+          documentId: "doc1",
+          jobId: "job1",
+          requestingUserId: userId,
+          reason: "TRANSIENT_ERROR",
+          lastError: "Error: 14 UNAVAILABLE",
+          retryCount: 0,
+          createdAt: Timestamp.now(),
+          nextRetryAt: Timestamp.fromMillis(0),
+        });
+
+      const updateStub = stub(DocumentReference.prototype, "update");
+      updateStub.callsFake(function (
+        this: DocumentReference,
+        ...args: Parameters<DocumentReference["update"]>
+      ): ReturnType<DocumentReference["update"]> {
+        // Only fail the worker's update against the target sample. Let
+        // pending-doc retry-state writebacks proceed normally.
+        if (
+          this.path.includes(
+            "/HealthObservations_HKQuantityTypeIdentifierHeartRate/",
+          ) &&
+          !this.path.includes("/pendingHealthSampleDeletions/")
+        ) {
+          const err = new Error("UNAVAILABLE") as Error & { code: number };
+          err.code = 14;
+          return Promise.reject(err);
+        }
+        return updateStub.wrappedMethod.apply(this, args);
+      });
+
+      const result = await queueService.processQueue();
+      expect(result.requeued).to.equal(1);
+      expect(result.succeeded).to.equal(0);
+
+      const queueSnapshot = await env.firestore
+        .collection("users")
+        .doc(userId)
+        .collection("pendingHealthSampleDeletions")
+        .get();
+      expect(queueSnapshot.size).to.equal(1);
+      const data = queueSnapshot.docs[0].data();
+      expect(data.retryCount).to.equal(1);
+      expect(data.lastError).to.equal("UNAVAILABLE");
+    });
+
+    it("should move item to dead-letter after max retries on transient errors", async () => {
+      const userId = await env.createUser({});
+
+      await env.firestore
+        .collection("users")
+        .doc(userId)
+        .collection("HealthObservations_HKQuantityTypeIdentifierHeartRate")
+        .doc("doc1")
+        .set({ status: "final", value: 72 });
+
+      await env.firestore
+        .collection("users")
+        .doc(userId)
+        .collection("pendingHealthSampleDeletions")
+        .add({
+          userId,
+          collection: "HealthObservations_HKQuantityTypeIdentifierHeartRate",
+          documentId: "doc1",
+          jobId: "job1",
+          requestingUserId: userId,
+          reason: "TRANSIENT_ERROR",
+          lastError: "Error: 4 DEADLINE_EXCEEDED",
+          retryCount: 9,
+          createdAt: Timestamp.now(),
+          nextRetryAt: Timestamp.fromMillis(0),
+        });
+
+      const updateStub = stub(DocumentReference.prototype, "update");
+      updateStub.callsFake(function (
+        this: DocumentReference,
+        ...args: Parameters<DocumentReference["update"]>
+      ): ReturnType<DocumentReference["update"]> {
+        if (
+          this.path.includes(
+            "/HealthObservations_HKQuantityTypeIdentifierHeartRate/",
+          ) &&
+          !this.path.includes("/pendingHealthSampleDeletions/")
+        ) {
+          const err = new Error("DEADLINE_EXCEEDED") as Error & {
+            code: number;
+          };
+          err.code = 4;
+          return Promise.reject(err);
+        }
+        return updateStub.wrappedMethod.apply(this, args);
+      });
+
+      const result = await queueService.processQueue();
+      expect(result.deadLettered).to.equal(1);
+
+      const pendingSnapshot = await env.firestore
+        .collection("users")
+        .doc(userId)
+        .collection("pendingHealthSampleDeletions")
+        .get();
+      expect(pendingSnapshot.size).to.equal(0);
+
+      const failedSnapshot = await env.firestore
+        .collection("users")
+        .doc(userId)
+        .collection("failedHealthSampleDeletions")
+        .get();
       expect(failedSnapshot.size).to.equal(1);
 
       const failedData = failedSnapshot.docs[0].data();
-      expect(failedData.documentId).to.equal("nonexistent-doc");
+      expect(failedData.documentId).to.equal("doc1");
       expect(failedData.retryCount).to.equal(10);
+      expect(failedData.lastError).to.equal("DEADLINE_EXCEEDED");
       expect(failedData.failedAt).to.be.an.instanceOf(Timestamp);
     });
 

--- a/functions/src/services/healthSamples/healthSampleDeletionQueueService.test.ts
+++ b/functions/src/services/healthSamples/healthSampleDeletionQueueService.test.ts
@@ -136,8 +136,9 @@ describeWithEmulators("service: HealthSampleDeletionQueueService", (env) => {
       expect(nextRetryMs).to.be.lessThanOrEqual(before + 32_000);
     });
 
-    it("should set nextRetryAt 60s in the future for TRANSIENT_ERROR", async () => {
+    it("should set nextRetryAt 8h in the future for TRANSIENT_ERROR", async () => {
       const before = Timestamp.now().toMillis();
+      const eightHoursMs = 8 * 60 * 60 * 1000;
 
       await queueService.enqueue({
         userId: "user1",
@@ -156,8 +157,8 @@ describeWithEmulators("service: HealthSampleDeletionQueueService", (env) => {
         .get();
       const data = snapshot.docs[0].data();
       const nextRetryMs = (data.nextRetryAt as Timestamp).toMillis();
-      expect(nextRetryMs).to.be.greaterThanOrEqual(before + 60_000);
-      expect(nextRetryMs).to.be.lessThanOrEqual(before + 62_000);
+      expect(nextRetryMs).to.be.greaterThanOrEqual(before + eightHoursMs);
+      expect(nextRetryMs).to.be.lessThanOrEqual(before + eightHoursMs + 2_000);
     });
   });
 
@@ -299,7 +300,7 @@ describeWithEmulators("service: HealthSampleDeletionQueueService", (env) => {
           requestingUserId: "user1",
           reason: "TRANSIENT_ERROR",
           lastError: "Error: 5 NOT_FOUND",
-          retryCount: 9,
+          retryCount: 2,
           createdAt: Timestamp.now(),
           nextRetryAt: Timestamp.fromMillis(0),
         });
@@ -389,7 +390,7 @@ describeWithEmulators("service: HealthSampleDeletionQueueService", (env) => {
           requestingUserId: userId,
           reason: "TRANSIENT_ERROR",
           lastError: "Error: 4 DEADLINE_EXCEEDED",
-          retryCount: 9,
+          retryCount: 2,
           createdAt: Timestamp.now(),
           nextRetryAt: Timestamp.fromMillis(0),
         });

--- a/functions/src/services/healthSamples/healthSampleDeletionQueueService.test.ts
+++ b/functions/src/services/healthSamples/healthSampleDeletionQueueService.test.ts
@@ -162,6 +162,26 @@ describeWithEmulators("service: HealthSampleDeletionQueueService", (env) => {
   });
 
   describe("processQueue", () => {
+    const stubTargetUpdateRejection = (
+      error: Error & { code: number },
+    ): void => {
+      const updateStub = stub(DocumentReference.prototype, "update");
+      updateStub.callsFake(function (
+        this: DocumentReference,
+        ...args: Parameters<DocumentReference["update"]>
+      ): ReturnType<DocumentReference["update"]> {
+        if (
+          this.path.includes(
+            "/HealthObservations_HKQuantityTypeIdentifierHeartRate/",
+          ) &&
+          !this.path.includes("/pendingHealthSampleDeletions/")
+        ) {
+          return Promise.reject(error);
+        }
+        return updateStub.wrappedMethod.apply(this, args);
+      });
+    };
+
     it("should return zeros when queue is empty", async () => {
       const result = await queueService.processQueue();
       expect(result.processed).to.equal(0);
@@ -324,25 +344,13 @@ describeWithEmulators("service: HealthSampleDeletionQueueService", (env) => {
           nextRetryAt: Timestamp.fromMillis(0),
         });
 
-      const updateStub = stub(DocumentReference.prototype, "update");
-      updateStub.callsFake(function (
-        this: DocumentReference,
-        ...args: Parameters<DocumentReference["update"]>
-      ): ReturnType<DocumentReference["update"]> {
-        // Only fail the worker's update against the target sample. Let
-        // pending-doc retry-state writebacks proceed normally.
-        if (
-          this.path.includes(
-            "/HealthObservations_HKQuantityTypeIdentifierHeartRate/",
-          ) &&
-          !this.path.includes("/pendingHealthSampleDeletions/")
-        ) {
-          const err = new Error("UNAVAILABLE") as Error & { code: number };
-          err.code = 14;
-          return Promise.reject(err);
-        }
-        return updateStub.wrappedMethod.apply(this, args);
-      });
+      // Fail only the worker's update against the target sample; let
+      // pending-doc retry-state writebacks proceed normally.
+      const transientError = new Error("UNAVAILABLE") as Error & {
+        code: number;
+      };
+      transientError.code = 14;
+      stubTargetUpdateRejection(transientError);
 
       const result = await queueService.processQueue();
       expect(result.requeued).to.equal(1);
@@ -386,25 +394,11 @@ describeWithEmulators("service: HealthSampleDeletionQueueService", (env) => {
           nextRetryAt: Timestamp.fromMillis(0),
         });
 
-      const updateStub = stub(DocumentReference.prototype, "update");
-      updateStub.callsFake(function (
-        this: DocumentReference,
-        ...args: Parameters<DocumentReference["update"]>
-      ): ReturnType<DocumentReference["update"]> {
-        if (
-          this.path.includes(
-            "/HealthObservations_HKQuantityTypeIdentifierHeartRate/",
-          ) &&
-          !this.path.includes("/pendingHealthSampleDeletions/")
-        ) {
-          const err = new Error("DEADLINE_EXCEEDED") as Error & {
-            code: number;
-          };
-          err.code = 4;
-          return Promise.reject(err);
-        }
-        return updateStub.wrappedMethod.apply(this, args);
-      });
+      const transientError = new Error("DEADLINE_EXCEEDED") as Error & {
+        code: number;
+      };
+      transientError.code = 4;
+      stubTargetUpdateRejection(transientError);
 
       const result = await queueService.processQueue();
       expect(result.deadLettered).to.equal(1);

--- a/functions/src/services/healthSamples/healthSampleDeletionQueueService.ts
+++ b/functions/src/services/healthSamples/healthSampleDeletionQueueService.ts
@@ -10,13 +10,14 @@ import type { PendingHealthSampleDeletion } from "./pendingHealthSampleDeletion.
 import { FHIRObservationStatus } from "../../models/index.js";
 import { CollectionsService } from "../database/collections.js";
 
-const MAX_QUEUE_RETRIES = 10;
+const MAX_QUEUE_RETRIES = 3;
 const QUEUE_BATCH_SIZE = 500;
 const QUEUE_CONCURRENCY_LIMIT = 10;
-const MAX_BACKOFF_MS = 3_600_000;
+const MAX_BACKOFF_MS = 48 * 60 * 60 * 1000;
 
 const NOT_FOUND_BASE_DELAY_MS = 30_000;
-const TRANSIENT_ERROR_BASE_DELAY_MS = 60_000;
+// 8h base + 2^retryCount → 16h, 32h between attempts; total ≈48h to drop.
+const TRANSIENT_ERROR_BASE_DELAY_MS = 8 * 60 * 60 * 1000;
 
 const PERMITTED_COLLECTION_PATTERN =
   /^(?:HealthObservations|SensorKitObservations)_[A-Za-z][A-Za-z0-9]*$/;

--- a/functions/src/services/healthSamples/healthSampleDeletionQueueService.ts
+++ b/functions/src/services/healthSamples/healthSampleDeletionQueueService.ts
@@ -15,10 +15,10 @@ const QUEUE_BATCH_SIZE = 500;
 const QUEUE_CONCURRENCY_LIMIT = 10;
 const MAX_BACKOFF_MS = 24 * 60 * 60 * 1000;
 
-const NOT_FOUND_BASE_DELAY_MS = 30_000;
-// Schedule for transient errors: enqueue waits 8h, then 16h between attempts,
-// then 24h (capped); 3 attempts span exactly 48h before the doc is dropped.
-const TRANSIENT_ERROR_BASE_DELAY_MS = 8 * 60 * 60 * 1000;
+// Retry schedule: enqueue waits 8h, then 16h between attempts, then 24h (capped);
+// 3 attempts span exactly 48h before the pending doc is dropped. Applies to both
+// NOT_FOUND (covers late-arriving uploads) and TRANSIENT_ERROR.
+const RETRY_BASE_DELAY_MS = 8 * 60 * 60 * 1000;
 
 const PERMITTED_COLLECTION_PATTERN =
   /^(?:HealthObservations|SensorKitObservations)_[A-Za-z][A-Za-z0-9]*$/;
@@ -69,11 +69,9 @@ export class HealthSampleDeletionQueueService {
     lastError: string | null;
   }): Promise<void> {
     const now = Timestamp.now();
-    const baseDelayMs =
-      params.reason === "NOT_FOUND" ?
-        NOT_FOUND_BASE_DELAY_MS
-      : TRANSIENT_ERROR_BASE_DELAY_MS;
-    const nextRetryAt = Timestamp.fromMillis(now.toMillis() + baseDelayMs);
+    const nextRetryAt = Timestamp.fromMillis(
+      now.toMillis() + RETRY_BASE_DELAY_MS,
+    );
 
     const sanitizedLastError =
       params.lastError !== null ?
@@ -263,14 +261,6 @@ export class HealthSampleDeletionQueueService {
       return "succeeded";
     } catch (error) {
       const sanitizedError = sanitizeErrorForStorage(error);
-
-      // NOT_FOUND on the target sample IS the desired end state of a
-      // deletion — clear the queue entry instead of retrying or dead-lettering.
-      if (sanitizedError === "NOT_FOUND") {
-        await doc.ref.delete();
-        return "succeeded";
-      }
-
       const newRetryCount = item.retryCount + 1;
 
       if (newRetryCount >= MAX_QUEUE_RETRIES) {
@@ -279,12 +269,8 @@ export class HealthSampleDeletionQueueService {
         return "dead-lettered";
       }
 
-      const baseDelayMs =
-        item.reason === "NOT_FOUND" ?
-          NOT_FOUND_BASE_DELAY_MS
-        : TRANSIENT_ERROR_BASE_DELAY_MS;
       const backoffMs = Math.min(
-        baseDelayMs * Math.pow(2, newRetryCount),
+        RETRY_BASE_DELAY_MS * Math.pow(2, newRetryCount),
         MAX_BACKOFF_MS,
       );
       const nextRetryAt = Timestamp.fromMillis(

--- a/functions/src/services/healthSamples/healthSampleDeletionQueueService.ts
+++ b/functions/src/services/healthSamples/healthSampleDeletionQueueService.ts
@@ -89,9 +89,26 @@ export class HealthSampleDeletionQueueService {
       nextRetryAt,
     };
 
-    await this.collections
+    // Deterministic doc id keeps re-enqueues idempotent: a duplicate
+    // request collapses onto the existing pending doc instead of spawning
+    // a new row, so worker-managed retry state isn't reset to zero.
+    const pendingId = `${params.collection}__${params.documentId}`;
+    const ref = this.collections
       .pendingHealthSampleDeletions(params.userId)
-      .add(item);
+      .doc(pendingId);
+
+    try {
+      await ref.create(item);
+    } catch (error) {
+      if (this.isAlreadyExistsError(error)) return;
+      throw error;
+    }
+  }
+
+  private isAlreadyExistsError(error: unknown): boolean {
+    if (error === null || typeof error !== "object") return false;
+    const code = (error as { code?: unknown }).code;
+    return code === 6 || code === "already-exists";
   }
 
   async processQueue(): Promise<{
@@ -257,6 +274,15 @@ export class HealthSampleDeletionQueueService {
       await doc.ref.delete();
       return "succeeded";
     } catch (error) {
+      const sanitizedError = sanitizeErrorForStorage(error);
+
+      // NOT_FOUND on the target sample IS the desired end state of a
+      // deletion — clear the queue entry instead of retrying or dead-lettering.
+      if (sanitizedError === "NOT_FOUND") {
+        await doc.ref.delete();
+        return "succeeded";
+      }
+
       const newRetryCount = item.retryCount + 1;
 
       if (newRetryCount >= MAX_QUEUE_RETRIES) {
@@ -275,7 +301,7 @@ export class HealthSampleDeletionQueueService {
         await this.collections.failedHealthSampleDeletions(ownerUserId).add({
           ...item,
           retryCount: newRetryCount,
-          lastError: sanitizeErrorForStorage(error),
+          lastError: sanitizedError,
           failedAt: Timestamp.now(),
         });
         await doc.ref.delete();
@@ -297,7 +323,7 @@ export class HealthSampleDeletionQueueService {
       await doc.ref.update({
         retryCount: newRetryCount,
         nextRetryAt,
-        lastError: sanitizeErrorForStorage(error),
+        lastError: sanitizedError,
       });
 
       return "requeued";

--- a/functions/src/services/healthSamples/healthSampleDeletionQueueService.ts
+++ b/functions/src/services/healthSamples/healthSampleDeletionQueueService.ts
@@ -13,10 +13,11 @@ import { CollectionsService } from "../database/collections.js";
 const MAX_QUEUE_RETRIES = 3;
 const QUEUE_BATCH_SIZE = 500;
 const QUEUE_CONCURRENCY_LIMIT = 10;
-const MAX_BACKOFF_MS = 48 * 60 * 60 * 1000;
+const MAX_BACKOFF_MS = 24 * 60 * 60 * 1000;
 
 const NOT_FOUND_BASE_DELAY_MS = 30_000;
-// 8h base + 2^retryCount → 16h, 32h between attempts; total ≈48h to drop.
+// Schedule for transient errors: enqueue waits 8h, then 16h between attempts,
+// then 24h (capped); 3 attempts span exactly 48h before the doc is dropped.
 const TRANSIENT_ERROR_BASE_DELAY_MS = 8 * 60 * 60 * 1000;
 
 const PERMITTED_COLLECTION_PATTERN =

--- a/functions/src/services/healthSamples/healthSampleDeletionQueueService.ts
+++ b/functions/src/services/healthSamples/healthSampleDeletionQueueService.ts
@@ -122,7 +122,6 @@ export class HealthSampleDeletionQueueService {
       .get();
 
     if (snapshot.empty) {
-      logger.info("No pending health sample deletions to process");
       return {
         processed: 0,
         succeeded: 0,
@@ -131,10 +130,6 @@ export class HealthSampleDeletionQueueService {
         skipped: 0,
       };
     }
-
-    logger.info(`Processing ${snapshot.size} pending health sample deletions`, {
-      count: snapshot.size,
-    });
 
     let succeeded = 0;
     let requeued = 0;
@@ -169,11 +164,6 @@ export class HealthSampleDeletionQueueService {
         );
       }
     }
-
-    logger.info(
-      `Queue processing complete: ${succeeded} succeeded, ${requeued} requeued, ${deadLettered} dead-lettered, ${skipped} skipped`,
-      { processed: snapshot.size, succeeded, requeued, deadLettered, skipped },
-    );
 
     return {
       processed: snapshot.size,
@@ -282,20 +272,7 @@ export class HealthSampleDeletionQueueService {
       const newRetryCount = item.retryCount + 1;
 
       if (newRetryCount >= MAX_QUEUE_RETRIES) {
-        // Final attempt exhausted — drop the pending doc rather than persist
-        // it indefinitely. The error log below is the durable signal for SRE.
-        logger.error(
-          `Dropping pending deletion after ${MAX_QUEUE_RETRIES} retries: '${item.documentId}' in '${item.collection}' for job '${item.jobId}'`,
-          {
-            jobId: item.jobId,
-            userId: ownerUserId,
-            collection: item.collection,
-            documentId: item.documentId,
-            retryCount: newRetryCount,
-            lastError: sanitizedError,
-          },
-        );
-
+        // Exhausted retries: drop the pending doc rather than persist it.
         await doc.ref.delete();
         return "dead-lettered";
       }

--- a/functions/src/services/healthSamples/healthSampleDeletionQueueService.ts
+++ b/functions/src/services/healthSamples/healthSampleDeletionQueueService.ts
@@ -286,24 +286,20 @@ export class HealthSampleDeletionQueueService {
       const newRetryCount = item.retryCount + 1;
 
       if (newRetryCount >= MAX_QUEUE_RETRIES) {
+        // Final attempt exhausted — drop the pending doc rather than persist
+        // it indefinitely. The error log below is the durable signal for SRE.
         logger.error(
-          `Moving item to dead-letter after ${MAX_QUEUE_RETRIES} retries: '${item.documentId}' in '${item.collection}' for job '${item.jobId}'`,
+          `Dropping pending deletion after ${MAX_QUEUE_RETRIES} retries: '${item.documentId}' in '${item.collection}' for job '${item.jobId}'`,
           {
             jobId: item.jobId,
             userId: ownerUserId,
             collection: item.collection,
             documentId: item.documentId,
             retryCount: newRetryCount,
-            lastError: String(error),
+            lastError: sanitizedError,
           },
         );
 
-        await this.collections.failedHealthSampleDeletions(ownerUserId).add({
-          ...item,
-          retryCount: newRetryCount,
-          lastError: sanitizedError,
-          failedAt: Timestamp.now(),
-        });
         await doc.ref.delete();
         return "dead-lettered";
       }

--- a/functions/src/services/healthSamples/healthSampleDeletionQueueService.ts
+++ b/functions/src/services/healthSamples/healthSampleDeletionQueueService.ts
@@ -26,6 +26,8 @@ const VALID_REASONS = new Set(["TRANSIENT_ERROR", "NOT_FOUND"]);
 const KNOWN_ERROR_CODES: Record<string | number, string> = {
   5: "NOT_FOUND",
   "not-found": "NOT_FOUND",
+  6: "ALREADY_EXISTS",
+  "already-exists": "ALREADY_EXISTS",
   4: "DEADLINE_EXCEEDED",
   "deadline-exceeded": "DEADLINE_EXCEEDED",
   8: "RESOURCE_EXHAUSTED",
@@ -100,15 +102,9 @@ export class HealthSampleDeletionQueueService {
     try {
       await ref.create(item);
     } catch (error) {
-      if (this.isAlreadyExistsError(error)) return;
+      if (sanitizeErrorForStorage(error) === "ALREADY_EXISTS") return;
       throw error;
     }
-  }
-
-  private isAlreadyExistsError(error: unknown): boolean {
-    if (error === null || typeof error !== "object") return false;
-    const code = (error as { code?: unknown }).code;
-    return code === 6 || code === "already-exists";
   }
 
   async processQueue(): Promise<{

--- a/functions/src/services/healthSamples/healthSampleDeletionService.ts
+++ b/functions/src/services/healthSamples/healthSampleDeletionService.ts
@@ -25,9 +25,6 @@ export class HealthSampleDeletionService {
   // errors that occur when hundreds of concurrent ops saturate the connection pool.
   private readonly CONCURRENCY_LIMIT = 25;
 
-  // Log a progress line every N documents so long jobs stay observable.
-  private readonly PROGRESS_LOG_INTERVAL = 1000;
-
   // gRPC / Firebase error codes that are safe to retry automatically.
   // Numeric codes come from raw gRPC transport; string codes from FirestoreError.
   // 4 / "deadline-exceeded"  – DEADLINE_EXCEEDED
@@ -64,46 +61,22 @@ export class HealthSampleDeletionService {
     collection: string,
     documentIds: string[],
   ): Promise<HealthSampleDeletionResult> {
-    logger.info(
-      `Starting async entered-in-error marking job '${jobId}': processing ${documentIds.length} samples in collection '${collection}' with concurrency limit ${this.CONCURRENCY_LIMIT}`,
-      {
-        jobId,
-        requestingUserId,
-        targetUserId,
-        collection,
-        totalSamples: documentIds.length,
-        concurrencyLimit: this.CONCURRENCY_LIMIT,
-      },
-    );
-
     let totalMarked = 0;
     let totalSkipped = 0;
     let totalFailed = 0;
     let totalQueued = 0;
-    let processed = 0;
 
     const results = await this.runWithConcurrencyLimit(
       documentIds,
       this.CONCURRENCY_LIMIT,
-      async (documentId) => {
-        const result = await this.markSampleAsEnteredInError(
+      async (documentId) =>
+        this.markSampleAsEnteredInError(
           targetUserId,
           collection,
           documentId,
           jobId,
           requestingUserId,
-        );
-
-        processed++;
-        if (processed % this.PROGRESS_LOG_INTERVAL === 0) {
-          logger.info(
-            `Job '${jobId}' progress: ${processed}/${documentIds.length} processed`,
-            { jobId, processed, total: documentIds.length },
-          );
-        }
-
-        return result;
-      },
+        ),
     );
 
     for (const result of results) {
@@ -133,22 +106,6 @@ export class HealthSampleDeletionService {
     const successRate =
       ((totalMarked / documentIds.length) * 100).toFixed(2) + "%";
 
-    logger.info(
-      `Async entered-in-error marking job '${jobId}' completed: ${totalMarked} marked, ${totalQueued} queued, ${totalSkipped} skipped (not found), ${totalFailed} failed out of ${documentIds.length} total`,
-      {
-        jobId,
-        requestingUserId,
-        targetUserId,
-        collection,
-        totalSamples: documentIds.length,
-        totalMarked,
-        totalQueued,
-        totalSkipped,
-        totalFailed,
-        successRate,
-      },
-    );
-
     return { totalMarked, totalSkipped, totalFailed, totalQueued, successRate };
   }
 
@@ -174,63 +131,17 @@ export class HealthSampleDeletionService {
       await this.withRetry(() =>
         ref.update({ status: FHIRObservationStatus.entered_in_error }),
       );
-
-      logger.debug(
-        `Marked sample as entered-in-error in job '${jobId}': '${documentId}' from collection '${collection}'`,
-        {
-          jobId,
-          requestingUserId,
-          targetUserId: userId,
-          collection,
-          documentId,
-        },
-      );
-
       return { success: true };
     } catch (error) {
-      if (this.isNotFoundError(error)) {
-        await this.queueService.enqueue({
-          userId,
-          collection,
-          documentId,
-          jobId,
-          requestingUserId,
-          reason: "NOT_FOUND",
-          lastError: String(error),
-        });
-        logger.info(
-          `Queued not-found sample for retry in job '${jobId}': '${documentId}' in collection '${collection}'`,
-          {
-            jobId,
-            requestingUserId,
-            targetUserId: userId,
-            collection,
-            documentId,
-          },
-        );
-        return { success: false, reason: "QUEUED" };
-      }
-
       await this.queueService.enqueue({
         userId,
         collection,
         documentId,
         jobId,
         requestingUserId,
-        reason: "TRANSIENT_ERROR",
+        reason: this.isNotFoundError(error) ? "NOT_FOUND" : "TRANSIENT_ERROR",
         lastError: String(error),
       });
-      logger.info(
-        `Queued failed sample for retry in job '${jobId}': '${documentId}' from collection '${collection}': ${String(error)}`,
-        {
-          jobId,
-          requestingUserId,
-          targetUserId: userId,
-          collection,
-          documentId,
-          error: String(error),
-        },
-      );
       return { success: false, reason: "QUEUED" };
     }
   }


### PR DESCRIPTION
# Remove pending 'to be deleted' HK Samples

## :recycle: Current situation & Problem
Currently, we store a lot of to be deleted HealthKit samples. This backlog grows currently quite fast; this PR implements two main fixes to keep the storage and function cost low.


## :gear: Release Notes
N/A


## :books: Documentation
N/A

## :white_check_mark: Testing
N/A

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
