### PR TITLE
Fix: "No document to update" / "Document already exists" failed-Commit audit entries

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -46,7 +46,8 @@ export * from "./functions/planNudges.js";
 export * from "./functions/planPosttrialNudges.js";
 export * from "./functions/sendNudges.js";
 export * from "./functions/onUserQuestionnaireResponseWritten.js";
-export * from "./functions/deleteHealthSamples.js";
+// Temporarily disabled 2026-06-09 to stop Firestore audit-log spam.
+// export * from "./functions/deleteHealthSamples.js";
 // Temporarily disabled 2026-05-06 for cost reduction.
 // During the freeze, uploads accumulate at users/*/liveHealthSamples/** in GCS.
 // Storage finalize triggers do NOT fire retroactively, so before re-enabling


### PR DESCRIPTION
# "No document to update" / "Document already exists" failed-Commit audit entries

## :recycle: Current situation & Problem
This PR disables deleteHealthSamples.js, which has contributed a lot of "No document to update" / "Document already exists" failed-Commit audit entries and can be disabled while we work on improving the general data pipeline.

## :gear: Release Notes
N/A


## :books: Documentation
N/A

## :white_check_mark: Testing
N/A

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
