### PR TITLE
Migrate repository references to SchmiedmayerLab

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,10 +17,10 @@ on:
 jobs:
   reuseaction:
     name: REUSE Compliance Check
-    uses: StanfordBDHG/.github/.github/workflows/reuse.yml@v2
+    uses: SchmiedmayerLab/.github/.github/workflows/reuse.yml@v0.2
   markdownlinkcheck:
     name: Markdown Link Check
-    uses: StanfordBDHG/.github/.github/workflows/markdown-link-check.yml@v2
+    uses: SchmiedmayerLab/.github/.github/workflows/markdown-links.yml@v0.2
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -46,21 +46,23 @@ jobs:
         uses: actions/checkout@v4
       - name: Determine Environment
         id: set-env
+        env:
+          REQUESTED_ENVIRONMENT: ${{ inputs.environment }}
         run: |
-          if [[ -z "${{ inputs.environment }}" ]]; then
-            echo "environment=staging" >> $GITHUB_OUTPUT
+          if [[ -z "$REQUESTED_ENVIRONMENT" ]]; then
+            echo "environment=staging" >> "$GITHUB_OUTPUT"
           else
-            echo "environment=${{ inputs.environment }}" >> $GITHUB_OUTPUT
+            echo "environment=$REQUESTED_ENVIRONMENT" >> "$GITHUB_OUTPUT"
           fi
       - name: Extract Region from Tag
         id: set-region
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/region-* ]]; then
-            REGION="${{ github.ref_name }}"
+          if [[ "$GITHUB_REF" == refs/tags/region-* ]]; then
+            REGION="$GITHUB_REF_NAME"
             REGION="${REGION#region-}"
-            echo "region=$REGION" >> $GITHUB_OUTPUT
+            echo "region=$REGION" >> "$GITHUB_OUTPUT"
           else
-            echo "region=" >> $GITHUB_OUTPUT
+            echo "region=" >> "$GITHUB_OUTPUT"
           fi
 
   vars:
@@ -93,10 +95,11 @@ jobs:
     name: Deploy Firebase Project
     if: needs.determineenvironment.outputs.environment != 'production'
     needs: [buildandtest, determineenvironment, vars]
-    uses: StanfordBDHG/.github/.github/workflows/firebase-deploy.yml@v2
+    uses: SchmiedmayerLab/.github/.github/workflows/firebase-deploy.yml@v0.2
     permissions:
       contents: read
     with:
+      nodeVersion: '22'
       customcommand: "npm run prepare"
       environment: ${{ needs.determineenvironment.outputs.environment }}
       arguments: '--project ${{ needs.vars.outputs.FIREBASE_PROJECT_ID }}'
@@ -108,25 +111,30 @@ jobs:
     name: Deploy Firebase Project (Production US)
     if: needs.determineenvironment.outputs.environment == 'production'
     needs: [buildandtest, determineenvironment, vars]
-    uses: StanfordBDHG/.github/.github/workflows/firebase-deploy.yml@v2
+    uses: SchmiedmayerLab/.github/.github/workflows/firebase-deploy.yml@v0.2
     permissions:
       contents: read
     with:
+      nodeVersion: '22'
       customcommand: "npm run prepare"
       environment: production
       arguments: '--project ${{ needs.vars.outputs.FIREBASE_PROJECT_ID_PRODUCTION_US }}'
     secrets:
       GOOGLE_APPLICATION_CREDENTIALS_BASE64: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_BASE64_PRODUCTION_US }}
 
-  # Deploy to UK after US succeeds
+  # Deploy to UK after US succeeds, once the UK project is configured.
   deployfirebase-production-uk:
     name: Deploy Firebase Project (Production UK)
-    if: needs.determineenvironment.outputs.environment == 'production'
+    if: >-
+      needs.determineenvironment.outputs.environment == 'production'
+      && needs.vars.outputs.FIREBASE_PROJECT_ID_PRODUCTION_UK != ''
+      && needs.vars.outputs.FIREBASE_PROJECT_ID_PRODUCTION_UK != 'TODO'
     needs: [deployfirebase-production-us, determineenvironment, vars]
-    uses: StanfordBDHG/.github/.github/workflows/firebase-deploy.yml@v2
+    uses: SchmiedmayerLab/.github/.github/workflows/firebase-deploy.yml@v0.2
     permissions:
       contents: read
     with:
+      nodeVersion: '22'
       customcommand: "npm run prepare"
       environment: production
       arguments: '--project ${{ needs.vars.outputs.FIREBASE_PROJECT_ID_PRODUCTION_UK }}'

--- a/.github/workflows/monthly-markdown-link-check.yml
+++ b/.github/workflows/monthly-markdown-link-check.yml
@@ -12,4 +12,4 @@ on:
 jobs:
   markdown_link_check:
     name: Markdown Link Check
-    uses: StanfordBDHG/.github/.github/workflows/markdown-link-check.yml@v2
+    uses: SchmiedmayerLab/.github/.github/workflows/markdown-links.yml@v0.2

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,7 +5,7 @@ SPDX-FileCopyrightText: 2025, 2026 Stanford University and the project authors (
 SPDX-License-Identifier: MIT
 -->
 
-# Stanford Biodesign Digital Health MyHeart Counts open-source project Contributors
+# My Heart Counts open-source project Contributors
 
 - [Paul Goldschmidt](https://github.com/paulgoldschmidt)
 - [Paul Johannes Kraft](https://github.com/pauljohanneskraft)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #
-# This source file is part of the Stanford Biodesign Digital Health MyHeart Counts open-source project
+# This source file is part of the My Heart Counts open-source project
 # Based on the docker file found at https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile.
 #
 # SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ This source file is part of the My Heart Counts project
 SPDX-FileCopyrightText: 2025, 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
 SPDX-License-Identifier: MIT
 -->
-[![Build and Test](https://github.com/StanfordBDHG/MyHeartCounts-Firebase/actions/workflows/build-and-test.yml/badge.svg?branch=main)](https://github.com/StanfordBDHG/MyHeartCounts-Firebase/actions/workflows/build-and-test.yml)
-[![CodeQL](https://github.com/StanfordBDHG/MyHeartCounts-Firebase/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/StanfordBDHG/MyHeartCounts-Firebase/actions/workflows/codeql.yml)
-[![Deployment](https://github.com/StanfordBDHG/MyHeartCounts-Firebase/actions/workflows/deployment.yml/badge.svg?branch=main)](https://github.com/StanfordBDHG/MyHeartCounts-Firebase/actions/workflows/deployment.yml)
+[![Build and Test](https://github.com/SchmiedmayerLab/MyHeartCounts-Firebase/actions/workflows/build-and-test.yml/badge.svg?branch=main)](https://github.com/SchmiedmayerLab/MyHeartCounts-Firebase/actions/workflows/build-and-test.yml)
+[![CodeQL](https://github.com/SchmiedmayerLab/MyHeartCounts-Firebase/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/SchmiedmayerLab/MyHeartCounts-Firebase/actions/workflows/codeql.yml)
+[![Deployment](https://github.com/SchmiedmayerLab/MyHeartCounts-Firebase/actions/workflows/deployment.yml/badge.svg?branch=main)](https://github.com/SchmiedmayerLab/MyHeartCounts-Firebase/actions/workflows/deployment.yml)
 
 # My Heart Counts
 
 Firebase cloud hosting infrastructure for the Stanford My Heart Counts project.
 
-The iOS Application can be found in the [StanfordBDHG/MyHeartCounts-iOS](https://github.com/StanfordBDHG/MyHeartCounts-iOS) repository, the repository for the data analysis side of this study can be found over at [StanfordBDHG/MyHeartCounts-DataAnalysis](https://github.com/StanfordBDHG/MyHeartCounts-DataAnalysis).
+The iOS Application can be found in the [SchmiedmayerLab/MyHeartCounts-iOS](https://github.com/SchmiedmayerLab/MyHeartCounts-iOS) repository, the repository for the data analysis side of this study can be found over at [SchmiedmayerLab/MyHeartCounts-DataAnalysis](https://github.com/SchmiedmayerLab/MyHeartCounts-DataAnalysis).
 
-The study itself with its contents is defined in [StanfordBDHG/MyHeartCounts-StudyDefinitions](https://github.com/StanfordBDHG/MyHeartCounts-StudyDefinitions).
+The study itself with its contents is defined in [SchmiedmayerLab/MyHeartCounts-StudyDefinitions](https://github.com/SchmiedmayerLab/MyHeartCounts-StudyDefinitions).
 
 Key features of the backend infrastructure include:
 - User account setup using blocking functions
@@ -102,7 +102,7 @@ The following table provides an overview of all fields in the `/users/{USER-ID}`
 
 |Path|Purpose|
 |-|-|
-|`/public/mhcStudyBundle.spezistudybundle.aar`|This it the Study definition bundle auto-build by the workflow in [MyHeartCounts-StudyDefinitions](https://github.com/StanfordBDHG/MyHeartCounts-StudyDefinitions/blob/main/.github/workflows/publish-study-definition.yml)|
+|`/public/mhcStudyBundle.spezistudybundle.aar`|This it the Study definition bundle auto-build by the workflow in [MyHeartCounts-StudyDefinitions](https://github.com/SchmiedmayerLab/MyHeartCounts-StudyDefinitions/blob/main/.github/workflows/publish-study-definition.yml)|
 |`/user/{USER-ID}/consent`|PDF Files of every consent the user gave (this could be multiple in the case of consent revisions or re-signup by the user.)|
 |`/user/{USER-ID}/historicalHealthSamples/{HEALTHKIT.IDENTIFIER}{UUID}.json.zstd`|We collect health samples that were recorded before the user enrolled into the app, compress them via zstd and store them as-is in the folder historicalHealthSamples for future analytics|
 |`/user/{USER-ID}/liveHealthSamples/{UUID}.json.zstd`|Most recorded ongoing (new) health samples get directly uploaded into the Firestore NoSQL Database - however, if a large amount of data has accumulated, we archive these samples for server-side decoding and upload them into liveHealthSamples. **This folder will be empty most of the time!** On Upload, the function [onArchivedLiveHealthSampleUploaded.ts](functions/src/functions/onArchivedLiveHealthSampleUploaded.ts) gets triggered which upon successful unpacking and storing into the Firestore Database deletes the live health sample archive.|
@@ -600,12 +600,15 @@ flowchart TD
 
 ### Contributing
 
-Contributions to this project are welcome. Please make sure to read the [contribution guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md) and the [contributor covenant code of conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) first.
-
+Contributions to this project are welcome. Please make sure to read the [contribution guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md) and the [contributor covenant code of conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) first.
 
 ## License
 
-This project is licensed under the MIT License. See [Licenses](https://github.com/StanfordBDHG/MyHeartCounts-iOS/tree/main/LICENSES) for more information.
+This project is licensed under the MIT License. See [Licenses](https://github.com/SchmiedmayerLab/MyHeartCounts-Firebase/tree/main/LICENSES) for more information.
 
-![Stanford Biodesign Footer](https://raw.githubusercontent.com/StanfordBDHG/.github/main/assets/biodesign-footer-light.png#gh-light-mode-only)
-![Stanford Biodesign Footer](https://raw.githubusercontent.com/StanfordBDHG/.github/main/assets/biodesign-footer-dark.png#gh-dark-mode-only)
+## Our Research
+
+For more information, visit the [Schmiedmayer Lab GitHub organization](https://github.com/SchmiedmayerLab).
+
+![Stanford and Stanford Medicine logos](https://raw.githubusercontent.com/SchmiedmayerLab/.github/main/assets/stanford-footer-light.png#gh-light-mode-only)
+![Stanford and Stanford Medicine logos](https://raw.githubusercontent.com/SchmiedmayerLab/.github/main/assets/stanford-footer-dark.png#gh-dark-mode-only)

--- a/functions/src/functions/planNudges.ts
+++ b/functions/src/functions/planNudges.ts
@@ -111,7 +111,7 @@ export class NudgeService {
   // Methods
 
   private mapComorbidityKeyToDisease(key: string): Disease | null {
-    // These are defined for iOS in https://github.com/StanfordBDHG/MyHeartCounts-iOS/blob/main/MyHeartCounts/Account/Demographics/Comorbidities.swift.
+    // These are defined for iOS in https://github.com/SchmiedmayerLab/MyHeartCounts-iOS/blob/main/MyHeartCounts/Account/Demographics/Comorbidities.swift.
     switch (key) {
       case "heartFailure":
         return Disease.HEART_FAILURE;

--- a/functions/src/functions/planPosttrialNudges.ts
+++ b/functions/src/functions/planPosttrialNudges.ts
@@ -134,7 +134,7 @@ export class PosttrialNudgeService {
   // Methods
 
   private mapComorbidityKeyToDisease(key: string): Disease | null {
-    // These are defined for iOS in https://github.com/StanfordBDHG/MyHeartCounts-iOS/blob/main/MyHeartCounts/Account/Demographics/Comorbidities.swift.
+    // These are defined for iOS in https://github.com/SchmiedmayerLab/MyHeartCounts-iOS/blob/main/MyHeartCounts/Account/Demographics/Comorbidities.swift.
     switch (key) {
       case "heartFailure":
         return Disease.HEART_FAILURE;

--- a/functions/src/services/questionnaireResponse/nicotineScoringService.ts
+++ b/functions/src/services/questionnaireResponse/nicotineScoringService.ts
@@ -42,7 +42,7 @@ export class DefaultNicotineScoreCalculator implements NicotineScoreCalculator {
   }
 
   private smokingStatusToScore(smokingStatus: string): number | null {
-    // Lookup table based on iOS NicotineExposureCategoryValues enum: https://github.com/StanfordBDHG/MyHeartCounts-iOS/blob/main/MyHeartCounts/Heart%20Health%20Dashboard/CustomHealthSample.swift
+    // Lookup table based on iOS NicotineExposureCategoryValues enum: https://github.com/SchmiedmayerLab/MyHeartCounts-iOS/blob/main/MyHeartCounts/Heart%20Health%20Dashboard/CustomHealthSample.swift
     switch (smokingStatus) {
       case "never-smoked/vaped":
         return 0;

--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "myheartcounts-firebase",
   "version": "4.0.5",
   "license": "MIT",
-  "description": "Stanford Biodesign Digital Health MyHeart Counts open-source project",
+  "description": "My Heart Counts open-source project",
   "keywords": [
     "Stanford",
-    "Biodesign",
-    "My heart counts"
+    "SchmiedmayerLab",
+    "My Heart Counts"
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/StanfordBDHG/MyHeartCounts-Firebase"
+    "url": "https://github.com/SchmiedmayerLab/MyHeartCounts-Firebase"
   },
   "dependencies": {
     "firebase-admin": "^13.7.0",


### PR DESCRIPTION
## Summary

- migrate reusable workflow and repository references to SchmiedmayerLab
- update My Heart Counts branding and the canonical organization footer
- pin Firebase deployments to Node 22 and skip the unconfigured UK project

## Testing

- actionlint on changed workflows
- JSON validation
- git diff --check