### PR TITLE
Update document snapshots to use uuidv4 + translate timestamp in new feedback email into human-readable form

### DIFF
--- a/functions/src/functions/onFeedbackCreated.ts
+++ b/functions/src/functions/onFeedbackCreated.ts
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
 // SPDX-License-Identifier: MIT
 
+import { Timestamp } from "firebase-admin/firestore";
 import { logger } from "firebase-functions";
 import { onDocumentCreated } from "firebase-functions/v2/firestore";
 import { createTransport } from "nodemailer";
@@ -17,6 +18,25 @@ import {
   getSmtpUsername,
 } from "../env.js";
 import { privilegedServiceAccount } from "./helpers.js";
+
+// Renders in the submitter's timezone when the feedback carries one, e.g.
+// "Jul 31, 2026, 12:33:47 PM PDT".
+const formatTimestamp = (
+  timestamp: Timestamp,
+  timeZone: string | undefined,
+): string => {
+  const date = timestamp.toDate();
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      dateStyle: "medium",
+      timeStyle: "long",
+      timeZone: timeZone ?? "UTC",
+    }).format(date);
+  } catch {
+    // Invalid IANA timezone name in the feedback document
+    return date.toISOString();
+  }
+};
 
 const formatFeedbackEmail = (
   feedbackId: string,
@@ -34,9 +54,13 @@ const formatFeedbackEmail = (
     `--- Feedback Content ---`,
   ];
 
+  const timeZone =
+    typeof rest.timeZone === "string" ? rest.timeZone : undefined;
   for (const [key, value] of Object.entries(rest)) {
     const formatted =
-      typeof value === "string" ? value : JSON.stringify(value, null, 2);
+      typeof value === "string" ? value
+      : value instanceof Timestamp ? formatTimestamp(value, timeZone)
+      : JSON.stringify(value, null, 2);
     lines.push(`${key}: ${formatted}`);
   }
 

--- a/functions/src/functions/onUserDocumentSnapshot.ts
+++ b/functions/src/functions/onUserDocumentSnapshot.ts
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
 // SPDX-License-Identifier: MIT
 
+import { randomUUID } from "crypto";
 import { isDeepStrictEqual } from "util";
 import admin from "firebase-admin";
 import { Timestamp } from "firebase-admin/firestore";

--- a/functions/src/functions/onUserDocumentSnapshot.ts
+++ b/functions/src/functions/onUserDocumentSnapshot.ts
@@ -111,7 +111,10 @@ export const captureUserDocumentSnapshot = async (
         DEBOUNCE_WINDOW_MS;
     // Within the window: collapse the burst by overwriting the most recent
     // snapshot in place; otherwise append a new snapshot.
-    transaction.set(withinWindow ? latest.ref : snapshotsRef.doc(), payload);
+    transaction.set(
+      withinWindow ? latest.ref : snapshotsRef.doc(randomUUID()),
+      payload,
+    );
   });
 };
 


### PR DESCRIPTION
### :recycle: Current situation & Problem
For consistency, we should use uuid v4 to name the document snapshots themselves.

### :gear: Release Notes
n/a

### :books: Documentation
n/a

### :white_check_mark: Testing
n/a

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
