### PR TITLE
Add possibility to use generic LLM endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ flowchart TD
     F --> G{Days since enrollment?}
     G -->|7 days| H[Generate predefined nudges]
     G -->|14 days, Group 1| H
-    G -->|14 days, Group 2| I[Call OpenAI GPT-5.2]
+    G -->|14 days, Group 2| I[Call LLM API gateway gpt-5.2]
 
     I --> J[Build personalized context]
     J -->|age, diseases, stage, education, language| K[LLM generates 7 nudges]

--- a/functions/src/env.ts
+++ b/functions/src/env.ts
@@ -6,7 +6,8 @@
 import { defineSecret } from "firebase-functions/params";
 
 enum SecretKey {
-  OPENAI_API_KEY = "OPENAI_API_KEY",
+  LLM_API_KEY = "LLM_API_KEY",
+  LLM_API_BASE_URL = "LLM_API_BASE_URL",
   SMTP_HOST = "SMTP_HOST",
   SMTP_PORT = "SMTP_PORT",
   SMTP_USERNAME = "SMTP_USERNAME",
@@ -15,13 +16,20 @@ enum SecretKey {
   FEEDBACK_COORDINATOR_EMAIL = "FEEDBACK_COORDINATOR_EMAIL",
 }
 
-const openaiApiKey = defineSecret(SecretKey.OPENAI_API_KEY);
+// The LLM used for nudge generation is reached through an OpenAI-compatible
+// API. Both the key and the base URL are kept as secrets so the backing
+// provider can be swapped without a code change.
+const llmApiKey = defineSecret(SecretKey.LLM_API_KEY);
+const llmApiBaseUrl = defineSecret(SecretKey.LLM_API_BASE_URL);
 
-export const getOpenaiApiKey = (): string => openaiApiKey.value();
+export const getLlmApiKey = (): string => llmApiKey.value();
 
-export const getOpenaiSecretKeys = (): string[] => [SecretKey.OPENAI_API_KEY];
+export const getLlmApiBaseUrl = (): string => llmApiBaseUrl.value();
 
-export const openaiApiKeyParam: ReturnType<typeof defineSecret> = openaiApiKey;
+export const llmSecretParams: Array<ReturnType<typeof defineSecret>> = [
+  llmApiKey,
+  llmApiBaseUrl,
+];
 
 const smtpHost = defineSecret(SecretKey.SMTP_HOST);
 const smtpPort = defineSecret(SecretKey.SMTP_PORT);

--- a/functions/src/functions/planNudges.test.ts
+++ b/functions/src/functions/planNudges.test.ts
@@ -89,7 +89,7 @@ describeWithEmulators("function: planNudges", (env) => {
 
       const firstNudge = backlogSnapshot.docs[0].data();
       const firstNudgeDocId = backlogSnapshot.docs[0].id;
-      // Should fall back to nudge-predefined nudges when OpenAI API key is not available
+      // Should fall back to nudge-predefined nudges when the LLM API key is not available
       expect(firstNudge.category).to.equal("nudge-predefined");
       expect(firstNudge.title).to.be.a("string");
       expect(firstNudge.body).to.be.a("string");
@@ -133,7 +133,7 @@ describeWithEmulators("function: planNudges", (env) => {
       expect(backlogSnapshot.size).to.equal(7);
 
       const firstNudge = backlogSnapshot.docs[0].data();
-      // Should fall back to nudge-predefined nudges when OpenAI API key is not available
+      // Should fall back to nudge-predefined nudges when the LLM API key is not available
       expect(firstNudge.category).to.equal("nudge-predefined");
       expect(firstNudge.isLLMGenerated).to.not.be.true;
     });
@@ -253,7 +253,7 @@ describeWithEmulators("function: planNudges", (env) => {
       expect(backlogSnapshot.size).to.equal(0);
     });
 
-    it("handles OpenAI API failures gracefully (falls back to nudge-predefined)", async () => {
+    it("handles LLM API failures gracefully (falls back to nudge-predefined)", async () => {
       const enrollmentDate = new Date();
       enrollmentDate.setDate(enrollmentDate.getDate() - 14);
 
@@ -323,7 +323,7 @@ describeWithEmulators("function: planNudges", (env) => {
       expect(backlogSnapshot.size).to.equal(7);
 
       const firstNudge = backlogSnapshot.docs[0].data();
-      // Should fall back to nudge-predefined nudges when OpenAI API key is not available
+      // Should fall back to nudge-predefined nudges when the LLM API key is not available
       expect(firstNudge.category).to.equal("nudge-predefined");
       expect(firstNudge.isLLMGenerated).to.not.be.true;
 

--- a/functions/src/functions/planNudges.test.ts
+++ b/functions/src/functions/planNudges.test.ts
@@ -89,7 +89,7 @@ describeWithEmulators("function: planNudges", (env) => {
 
       const firstNudge = backlogSnapshot.docs[0].data();
       const firstNudgeDocId = backlogSnapshot.docs[0].id;
-      // Should fall back to nudge-predefined nudges when the LLM API key is not available
+      // Should fall back to nudge-predefined nudges when the LLM configuration (LLM_API_KEY / LLM_API_BASE_URL) is unavailable or a gateway, network, or response-format error occurs
       expect(firstNudge.category).to.equal("nudge-predefined");
       expect(firstNudge.title).to.be.a("string");
       expect(firstNudge.body).to.be.a("string");
@@ -133,7 +133,7 @@ describeWithEmulators("function: planNudges", (env) => {
       expect(backlogSnapshot.size).to.equal(7);
 
       const firstNudge = backlogSnapshot.docs[0].data();
-      // Should fall back to nudge-predefined nudges when the LLM API key is not available
+      // Should fall back to nudge-predefined nudges when the LLM configuration (LLM_API_KEY / LLM_API_BASE_URL) is unavailable or a gateway, network, or response-format error occurs
       expect(firstNudge.category).to.equal("nudge-predefined");
       expect(firstNudge.isLLMGenerated).to.not.be.true;
     });
@@ -323,7 +323,7 @@ describeWithEmulators("function: planNudges", (env) => {
       expect(backlogSnapshot.size).to.equal(7);
 
       const firstNudge = backlogSnapshot.docs[0].data();
-      // Should fall back to nudge-predefined nudges when the LLM API key is not available
+      // Should fall back to nudge-predefined nudges when the LLM configuration (LLM_API_KEY / LLM_API_BASE_URL) is unavailable or a gateway, network, or response-format error occurs
       expect(firstNudge.category).to.equal("nudge-predefined");
       expect(firstNudge.isLLMGenerated).to.not.be.true;
 

--- a/functions/src/functions/planNudges.ts
+++ b/functions/src/functions/planNudges.ts
@@ -9,7 +9,7 @@ import { logger } from "firebase-functions";
 import { onSchedule } from "firebase-functions/v2/scheduler";
 import { DateTime } from "luxon";
 import OpenAI from "openai";
-import { getOpenaiApiKey, openaiApiKeyParam } from "../env.js";
+import { getLlmApiBaseUrl, getLlmApiKey, llmSecretParams } from "../env.js";
 import { privilegedServiceAccount } from "./helpers.js";
 import {
   getPredefinedNudgeMessages,
@@ -75,7 +75,9 @@ const mhcGenderIdentityMap: Partial<Record<number, string>> = {
   5: "other",
 };
 
-const LLM_MODEL = "gpt-5.2-2025-12-11";
+// Model ID as exposed by the configured LLM API gateway. Must be one of the
+// models the gateway API key has access to.
+const LLM_MODEL = "gpt-5.2";
 
 // Version of the LLM prompt template built in generateLLMNudges. Bump this
 // whenever the prompt wording changes so generated nudges can be traced back
@@ -438,11 +440,14 @@ export class NudgeService {
 
         const prompt = `Write 7 motivational messages that are of proper length to go in a push notification using a calm, encouraging, and professional tone, like that of a health coach to motivate a smartphone user to increase their daily physical activity, prioritizing movement that contributes to their step count. Also create a title for each of the push notifications that is a short summary/call to action of the push notification that is paired with it. Return the response as a JSON array with exactly 7 objects, each having "title" and "body" fields. If there is a disease context given, you can reference that disease in some of the nudges. When generating nudges, avoid the word 'healthy' and remove unnecessary qualifiers such as 'brisk' or 'deep'. Suggest only simple, low-risk forms of movement without adding extra exercises or medical disclaimers not provided. Keep messages concise, calm, and practical; focus on one clear activity with plain language. Keep recommendations practical, varied, and easy to integrate into daily routines. NEVER USE EM DASHES, EMOJIS OR ABBREVIATIONS FOR DISEASES IN THE NUDGE. Each nudge should be personalized to the following information: ${languageContext} ${genderContext} ${ageContext} ${diseaseContext} ${stageContext} ${educationContext} ${notificationTimeContext} Think carefully before delivering the prompts to ensure they are personalized to the information given (especially any given disease context) and give recommendations based on research backed motivational methods.`;
 
-        const openai = new OpenAI({
-          apiKey: getOpenaiApiKey(),
+        // The configured LLM endpoint is OpenAI-compatible, so the OpenAI SDK
+        // is used as the client with the base URL pointed at the gateway.
+        const llmClient = new OpenAI({
+          apiKey: getLlmApiKey(),
+          baseURL: getLlmApiBaseUrl(),
         });
 
-        const response = await openai.chat.completions.create({
+        const response = await llmClient.chat.completions.create({
           model: LLM_MODEL,
           messages: [
             {
@@ -494,7 +499,7 @@ export class NudgeService {
         const parsedNudges = parsedContent.nudges;
 
         if (!Array.isArray(parsedNudges) || parsedNudges.length !== 7) {
-          throw new Error("Invalid response format from OpenAI API");
+          throw new Error("Invalid response format from LLM API");
         }
 
         const usage = response.usage;
@@ -795,7 +800,7 @@ export const onScheduleDailyNudgeCreation = onSchedule(
   {
     schedule: "0 8 * * *",
     timeZone: "UTC",
-    secrets: [openaiApiKeyParam],
+    secrets: llmSecretParams,
     serviceAccount: privilegedServiceAccount,
   },
   async () => {

--- a/functions/src/functions/planPosttrialNudges.test.ts
+++ b/functions/src/functions/planPosttrialNudges.test.ts
@@ -165,7 +165,7 @@ describeWithEmulators("function: planPosttrialNudges", (env) => {
   });
 
   describe("LLM failure — no fallback", () => {
-    it("creates 0 nudges when the OpenAI call fails (no predefined fallback)", async () => {
+    it("creates 0 nudges when the LLM call fails (no predefined fallback)", async () => {
       const userId = "posttrial-llm-failure";
       await env.firestore
         .collection("users")

--- a/functions/src/functions/planPosttrialNudges.ts
+++ b/functions/src/functions/planPosttrialNudges.ts
@@ -9,7 +9,7 @@ import { logger } from "firebase-functions";
 import { onSchedule } from "firebase-functions/v2/scheduler";
 import { DateTime } from "luxon";
 import OpenAI from "openai";
-import { getOpenaiApiKey, openaiApiKeyParam } from "../env.js";
+import { getLlmApiBaseUrl, getLlmApiKey, llmSecretParams } from "../env.js";
 import { privilegedServiceAccount } from "./helpers.js";
 import { type BaseNudgeMessage } from "./nudgeMessages.js";
 
@@ -86,7 +86,8 @@ const AVAILABLE_WORKOUT_TYPES = [
   "yoga/pilates",
 ] as const;
 
-const LLM_MODEL = "gpt-5.4-mini-2026-03-17";
+// Model ID as exposed by the configured LLM API gateway.
+const LLM_MODEL = "gpt-5-mini";
 
 // Version of the LLM prompt template built in generateLLMNudge. Bump this
 // whenever the prompt wording changes so generated nudges can be traced back
@@ -619,11 +620,14 @@ export class PosttrialNudgeService {
         // Prompt: Just one nudge, include personalization context.
         const prompt = `Write 1 motivational message that is a proper length to go in a push notification using a calm, encouraging, and professional tone, like that of a health coach to motivate a smartphone user to increase their daily physical activity. Also create a title for the push notification that is a short summary/call to action of the push notification. Return the response as a JSON object with 'title' and 'body' fields. If there is a disease context given, you can reference that disease in the nudge. When generating the nudge, avoid the word 'healthy' and remove unnecessary qualifiers such as 'brisk' or 'deep'. Suggest only simple, low-risk forms of movement without adding extra exercises or medical disclaimers not provided. Keep the message concise, calm, and practical; focus on one clear activity with plain language. Keep the recommendation practical and easy to integrate into daily routines. NEVER USE EM DASHES, EMOJIS OR ABBREVIATIONS FOR DISEASES IN THE NUDGE. The nudge should be personalized to the following information: ${languageContext} ${genderContext} ${ageContext} ${diseaseContext} ${stageContext} ${educationContext} ${notificationTimeContext} ${activityTypeContext} ${previousNudgesContext} Think carefully before delivering the prompt to ensure it is personalized to the information given (especially any given disease context) and give recommendations based on research backed motivational methods${varietyClause}.`;
 
-        const openai = new OpenAI({
-          apiKey: getOpenaiApiKey(),
+        // The configured LLM endpoint is OpenAI-compatible, so the OpenAI SDK
+        // is used as the client with the base URL pointed at the gateway.
+        const llmClient = new OpenAI({
+          apiKey: getLlmApiKey(),
+          baseURL: getLlmApiBaseUrl(),
         });
 
-        const response = await openai.chat.completions.create({
+        const response = await llmClient.chat.completions.create({
           model: LLM_MODEL,
           messages: [
             {
@@ -664,7 +668,7 @@ export class PosttrialNudgeService {
           typeof parsedContent.title !== "string" ||
           typeof parsedContent.body !== "string"
         ) {
-          throw new Error("Invalid response format from OpenAI API");
+          throw new Error("Invalid response format from LLM API");
         }
 
         const usage = response.usage;
@@ -956,7 +960,7 @@ export const onScheduleDailyPosttrialNudgeCreation = onSchedule(
   {
     schedule: "30 8 * * *",
     timeZone: "UTC",
-    secrets: [openaiApiKeyParam],
+    secrets: llmSecretParams,
     serviceAccount: privilegedServiceAccount,
   },
   async () => {


### PR DESCRIPTION
### :recycle: Current situation & Problem
We want to support different LLM endpoints for nudges to make MHC more flexible.


### :gear: Release Notes
n/a

### :books: Documentation
updated readme/docs


### :white_check_mark: Testing
test cases updated, will do pre-release testing before pushing to prod.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
