### PR TITLE
Up the nudge generation timeout limit to 30mins

### DIFF
--- a/functions/src/functions/planNudges.ts
+++ b/functions/src/functions/planNudges.ts
@@ -79,6 +79,8 @@ const mhcGenderIdentityMap: Partial<Record<number, string>> = {
 // models the gateway API key has access to.
 const LLM_MODEL = "gpt-5.2";
 
+const LLM_REQUEST_TIMEOUT_MS = 60_000;
+
 // Version of the LLM prompt template built in generateLLMNudges. Bump this
 // whenever the prompt wording changes so generated nudges can be traced back
 // to the exact prompt version that produced them.
@@ -445,6 +447,8 @@ export class NudgeService {
         const llmClient = new OpenAI({
           apiKey: getLlmApiKey(),
           baseURL: getLlmApiBaseUrl(),
+          timeout: LLM_REQUEST_TIMEOUT_MS,
+          maxRetries: 0, // the enclosing attempt loop handles retries
         });
 
         const response = await llmClient.chat.completions.create({
@@ -800,6 +804,7 @@ export const onScheduleDailyNudgeCreation = onSchedule(
   {
     schedule: "0 8 * * *",
     timeZone: "UTC",
+    timeoutSeconds: 1800,
     secrets: llmSecretParams,
     serviceAccount: privilegedServiceAccount,
   },

--- a/functions/src/functions/planPosttrialNudges.ts
+++ b/functions/src/functions/planPosttrialNudges.ts
@@ -89,6 +89,8 @@ const AVAILABLE_WORKOUT_TYPES = [
 // Model ID as exposed by the configured LLM API gateway.
 const LLM_MODEL = "gpt-5-mini";
 
+const LLM_REQUEST_TIMEOUT_MS = 60_000;
+
 // Version of the LLM prompt template built in generateLLMNudge. Bump this
 // whenever the prompt wording changes so generated nudges can be traced back
 // to the exact prompt version that produced them.
@@ -625,6 +627,8 @@ export class PosttrialNudgeService {
         const llmClient = new OpenAI({
           apiKey: getLlmApiKey(),
           baseURL: getLlmApiBaseUrl(),
+          timeout: LLM_REQUEST_TIMEOUT_MS,
+          maxRetries: 0, // the enclosing attempt loop handles retries
         });
 
         const response = await llmClient.chat.completions.create({
@@ -960,6 +964,7 @@ export const onScheduleDailyPosttrialNudgeCreation = onSchedule(
   {
     schedule: "30 8 * * *",
     timeZone: "UTC",
+    timeoutSeconds: 1800,
     secrets: llmSecretParams,
     serviceAccount: privilegedServiceAccount,
   },


### PR DESCRIPTION
### :recycle: Current situation & Problem
We are hitting the limits of the default execution time while generating (post trial) nudges with the new LLM backend, which has higher latency then before. Therefore, we need to raise the function execution time limit.

### :gear: Release Notes
Ups from 60 seconds to 1800 seconds

### :books: Documentation
n/a

### :white_check_mark: Testing
n/a

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/SchmiedmayerLab/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SchmiedmayerLab/.github/blob/main/CONTRIBUTING.md).
